### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/04_data_science_tools.Rmd
+++ b/04_data_science_tools.Rmd
@@ -46,7 +46,7 @@ This won't solve things like inconsistent values and colour-coded cells, but it 
 For more about the principles of tidy data, see Hadley Wickham's article "Tidy data", in _The Journal of Statistical Software_ [@tidydata]
 
   + [alternate link:](http://vita.had.co.nz/papers/tidy-data.html)
-  + [informal and code-heavy version](https://cran.r-project.org/web/packages/tidyr/vignettes/tidy-data.html)
+  + [informal and code-heavy version](https://cran.r-project.org/package=tidyr/vignettes/tidy-data.html)
  
 
 ### Other tidyverse references

--- a/11_data_sources.rmd
+++ b/11_data_sources.rmd
@@ -55,7 +55,7 @@ Dmitry Shkolnik (2018-08-01) [The CANSIM package, Canadian tourism, and slopegra
 
 ### **CANSIM2R**
 
-[CANSIM2R: Directly Extracts Complete CANSIM Data Tables](https://cran.r-project.org/web/packages/CANSIM2R/index.html)
+[CANSIM2R: Directly Extracts Complete CANSIM Data Tables](https://cran.r-project.org/package=CANSIM2R)
 
 github: [CANSIM2R](https://github.com/MarcoLugo/CANSIM2R)
 
@@ -64,12 +64,12 @@ github: [CANSIM2R](https://github.com/MarcoLugo/CANSIM2R)
 
 ### **gapminder**
 
-[gapminder: Data from Gapminder](https://cran.r-project.org/web/packages/gapminder/index.html) An excerpt of the data available at [Gapminder.org]. For each of 142 countries, the package provides values for life expectancy, GDP per capita, and population, every five years, from 1952 to 2007. 
+[gapminder: Data from Gapminder](https://cran.r-project.org/package=gapminder) An excerpt of the data available at [Gapminder.org]. For each of 142 countries, the package provides values for life expectancy, GDP per capita, and population, every five years, from 1952 to 2007. 
 
 
 ### **Lahman**
 
-[Lahman: Sean 'Lahman' Baseball Database](https://cran.r-project.org/web/packages/Lahman/)  Provides the tables from the 'Sean Lahman Baseball Database' as a set of R data.frames. It uses the data on pitching, hitting and fielding performance and other tables from 1871 through 2015, as recorded in the 2016 version of the database.
+[Lahman: Sean 'Lahman' Baseball Database](https://cran.r-project.org/package=Lahman/)  Provides the tables from the 'Sean Lahman Baseball Database' as a set of R data.frames. It uses the data on pitching, hitting and fielding performance and other tables from 1871 through 2015, as recorded in the 2016 version of the database.
 
 
 

--- a/12_data_reading_fileformat.rmd
+++ b/12_data_reading_fileformat.rmd
@@ -29,7 +29,7 @@ In particular, survey data
 
 CRAN page: _currently only development version_, see tidyverse link below 
 
-vignette: [Import, Export, and Convert Data Files](https://cran.r-project.org/web/packages/rio/vignettes/rio.html)
+vignette: [Import, Export, and Convert Data Files](https://cran.r-project.org/package=rio/vignettes/rio.html)
 
 
 
@@ -82,11 +82,11 @@ CRAN page: [TSdbi: Time Series Database Interface]( https://CRAN.R-project.org/p
 
 Note: `TSdbi` has some related extension packages:
 
-* CRAN page: [TSdata: 'TSdbi' Illustration](https://cran.r-project.org/web/packages/TSdata/index.html)
+* CRAN page: [TSdata: 'TSdbi' Illustration](https://cran.r-project.org/package=TSdata)
 *  This package gives an overview and usage examples for all the `TSdbi` family of packages
 
-* CRAN page: [TSPostgreSQL: 'TSdbi' Extensions for 'PostgreSQL'](https://cran.r-project.org/web/packages/TSPostgreSQL/index.html)
+* CRAN page: [TSPostgreSQL: 'TSdbi' Extensions for 'PostgreSQL'](https://cran.r-project.org/package=TSPostgreSQL)
 
-* CRAN page: [TSsdmx: 'TSdbi' Extension to Connect with 'SDMX'](https://cran.r-project.org/web/packages/TSsdmx/index.html)
+* CRAN page: [TSsdmx: 'TSdbi' Extension to Connect with 'SDMX'](https://cran.r-project.org/package=TSsdmx)
 
 

--- a/13_api.Rmd
+++ b/13_api.Rmd
@@ -36,9 +36,9 @@ Jose Gonzalez, [Using Google Maps API and R](https://gist.github.com/josecarlosg
 
 #### `httr`
 
-CRAN: [httr: Tools for Working with URLs and HTTP](https://cran.r-project.org/web/packages/httr/)
+CRAN: [httr: Tools for Working with URLs and HTTP](https://cran.r-project.org/package=httr/)
 
-Vignette: [Best practices for API packages](https://cran.r-project.org/web/packages/httr/vignettes/api-packages.html)
+Vignette: [Best practices for API packages](https://cran.r-project.org/package=httr/vignettes/api-packages.html)
 
 
 

--- a/15_anonymity_confidentiality.Rmd
+++ b/15_anonymity_confidentiality.Rmd
@@ -188,7 +188,7 @@ John Mount (1012) ["Modeling Trick: Masked Variables"](http://www.win-vector.com
 
 **package**
 
-CRAN page: [sdcMicro: Statistical Disclosure Control Methods for Anonymization of Microdata and Risk Estimation](https://cran.r-project.org/web/packages/sdcMicro/index.html)
+CRAN page: [sdcMicro: Statistical Disclosure Control Methods for Anonymization of Microdata and Risk Estimation](https://cran.r-project.org/package=sdcMicro)
 
 github page: [sdcMicro](https://github.com/sdcTools) (note: this is a sub-page for for a broader set of SDC tools)
 
@@ -199,7 +199,7 @@ github page: [sdcMicro](https://github.com/sdcTools) (note: this is a sub-page f
 
 Matthias Templ, ["Statistical Disclosure Control for Microdata Using the R-Package sdcMicro"](http://www.tdp.cat/issues/tdp.a004a08.pdf), _Transactions on Data Privacy_ 1 (2008) 67–85.
 
-Matthias Templ, Bernhard Meindl and Alexander Kowarik, [Introduction to Statistical Disclosure Control (SDC)](https://cran.r-project.org/web/packages/sdcMicro/vignettes/sdc_guidelines.pdf), 2015/2017
+Matthias Templ, Bernhard Meindl and Alexander Kowarik, [Introduction to Statistical Disclosure Control (SDC)](https://cran.r-project.org/package=sdcMicro/vignettes/sdc_guidelines.pdf), 2015/2017
 
 Matthias Templ, Alexander Kowarik, Bernhard Meindl (2015) ["Statistical Disclosure Control for Micro-Data Using the R Package sdcMicro"](https://www.jstatsoft.org/article/view/v067i04), _Journal of Statistical Software_, Vol.67 No.4 
 
@@ -213,26 +213,26 @@ Daniel Abril, Guillermo Navarro-Arribas and Vicenç Torra (2015) ["Data Privacy 
 
 **package**
 
-CRAN page: [sdcMicroGUI: Graphical User Interface for Package 'sdcMicro'](https://cran.r-project.org/web/packages/sdcMicroGUI/index.html)
+CRAN page: [sdcMicroGUI: Graphical User Interface for Package 'sdcMicro'](https://cran.r-project.org/package=sdcMicroGUI)
 
 **articles**
 
-Matthias Templ, Bernhard Meindl and Alexander Kowarik, [Tutorial for sdcMicroGUI (and sdcMicro)](https://cran.r-project.org/web/packages/sdcMicroGUI/vignettes/gui_tutorial.pdf), 2015
+Matthias Templ, Bernhard Meindl and Alexander Kowarik, [Tutorial for sdcMicroGUI (and sdcMicro)](https://cran.r-project.org/package=sdcMicroGUI/vignettes/gui_tutorial.pdf), 2015
 
 
 
 ### **sdcTable**
 
-CRAN page: [sdcTable: Methods for Statistical Disclosure Control in Tabular Data](https://cran.r-project.org/web/packages/sdcTable/index.html)
+CRAN page: [sdcTable: Methods for Statistical Disclosure Control in Tabular Data](https://cran.r-project.org/package=sdcTable)
 
 
 ### **easySdcTable**
 
 ** package**
 
-CRAN page: [easySdcTable: Easy Interface to the Statistical Disclosure Control Package 'sdcTable'](https://cran.r-project.org/web/packages/easySdcTable/)
+CRAN page: [easySdcTable: Easy Interface to the Statistical Disclosure Control Package 'sdcTable'](https://cran.r-project.org/package=easySdcTable/)
 
-vignette: [`easySdcTable` Vignette](https://cran.r-project.org/web/packages/easySdcTable/vignettes/easySdcTableVignette.html)
+vignette: [`easySdcTable` Vignette](https://cran.r-project.org/package=easySdcTable/vignettes/easySdcTableVignette.html)
 
 
 
@@ -240,7 +240,7 @@ vignette: [`easySdcTable` Vignette](https://cran.r-project.org/web/packages/easy
 
 **package**
 
-CRAN page: [digest: Create Compact Hash Digests of R Objects](https://cran.r-project.org/web/packages/digest/index.html)
+CRAN page: [digest: Create Compact Hash Digests of R Objects](https://cran.r-project.org/package=digest)
 
 **articles**
 

--- a/20_data_wrangling.Rmd
+++ b/20_data_wrangling.Rmd
@@ -66,7 +66,7 @@ Working with factors
 
 [reference page](https://purrr.tidyverse.org/)
 
-CRAN: [purrr: Functional Programming Tools](https://cran.r-project.org/web/packages/purrr/index.html)
+CRAN: [purrr: Functional Programming Tools](https://cran.r-project.org/package=purrr)
 
 
 **tutorials**

--- a/41_chart_types.Rmd
+++ b/41_chart_types.Rmd
@@ -60,7 +60,7 @@ A.K.A. bar and line graphs. Don't use them!
 > an eikosogram is a picture of probability. It visually partitions a unit square into rectangular regions whose areas give the numerical values of various probabilities. The construction is such that each rectangular region is identified with the value of one or more categorical variates. 
 > _R.W. Oldford_
 
-* R.W. Oldford (2018-08-16) [Introduction to eikosograms](https://cran.r-project.org/web/packages/eikosograms/vignettes/introduction.html)
+* R.W. Oldford (2018-08-16) [Introduction to eikosograms](https://cran.r-project.org/package=eikosograms/vignettes/introduction.html)
 
 
 
@@ -119,7 +119,7 @@ Tim RiffeEmail author, Jonas Schöley and Francisco Villavicencio (2017) ["A uni
 
 * [github repo](https://github.com/rich-iannone/DiagrammeR)
 
-* [DiagrammeRsvg: Export DiagrammeR Graphviz Graphs as SVG](https://cran.r-project.org/web/packages/DiagrammeRsvg/index.html)
+* [DiagrammeRsvg: Export DiagrammeR Graphviz Graphs as SVG](https://cran.r-project.org/package=DiagrammeRsvg)
 
 
 [ggnet2: network visualization with ggplot2](https://briatte.github.io/ggnet/) -- part of the [`GGally`](https://www.rdocumentation.org/packages/GGally/versions/1.3.2) package
@@ -181,7 +181,7 @@ acarioli (2016-01-11) [Population pyramids in ggplot](https://aledemogr.wordpres
 
 ** ridgeline plots in R **
 
-[`ggridges` package by Claus Wilke](https://cran.r-project.org/web/packages/ggridges/index.html) -- CRAN page
+[`ggridges` package by Claus Wilke](https://cran.r-project.org/package=ggridges) -- CRAN page
 
 Alex Whan, 2016-03-24, [ggplot2 and Joy Division](http://alexwhan.com/2016-03-24-joy-division-plot) - at Incrutable Errors
 

--- a/50_quantitative_methods.Rmd
+++ b/50_quantitative_methods.Rmd
@@ -50,14 +50,14 @@ CRAN page: [Random {base}: Random number generation](http://stat.ethz.ch/R-manua
 
 **package**
 
-CRAN page: [random: True Random Numbers using RANDOM.ORG](https://cran.r-project.org/web/packages/random/)
+CRAN page: [random: True Random Numbers using RANDOM.ORG](https://cran.r-project.org/package=random/)
 
 
 #### `sampling`
 
 **package**
 
-CRAN page: [sampling: Survey Sampling](https://cran.r-project.org/web/packages/sampling/index.html)
+CRAN page: [sampling: Survey Sampling](https://cran.r-project.org/package=sampling)
 
 **articles**
 

--- a/51_bayesian.Rmd
+++ b/51_bayesian.Rmd
@@ -62,7 +62,7 @@ easystats (2019-04-15) [Describe and understand Bayesian models and posteriors u
 
 **package**
 
-CRAN page: [rjags: Bayesian Graphical Models using MCMC](https://cran.r-project.org/web/packages/rjags/index.html)
+CRAN page: [rjags: Bayesian Graphical Models using MCMC](https://cran.r-project.org/package=rjags)
 
 **articles**
 
@@ -73,7 +73,7 @@ Alicia Johnson: [Bayesian modeling with `rjags`] {link to DataCamp course remove
 
 **package**
 
-CRAN page: [tidybayes: Tidy Data and 'Geoms' for Bayesian Models](https://cran.r-project.org/web/packages/tidybayes/index.html)
+CRAN page: [tidybayes: Tidy Data and 'Geoms' for Bayesian Models](https://cran.r-project.org/package=tidybayes)
 
 GitHub page: [Bayesian analysis + tidy data + geoms (R package)](https://github.com/mjskay/tidybayes)
 

--- a/52_machine_learning.Rmd
+++ b/52_machine_learning.Rmd
@@ -50,7 +50,7 @@ Jason Brownlee, 2016-02-23, [Your First Machine Learning Project in R Step-By-St
 
 **package**
 
-CRAN page: [h2o: R Interface for H2O](https://cran.r-project.org/web/packages/h2o/index.html)
+CRAN page: [h2o: R Interface for H2O](https://cran.r-project.org/package=h2o)
 
 **articles**
 

--- a/53_regression.Rmd
+++ b/53_regression.Rmd
@@ -47,18 +47,18 @@ http://andrewgelman.com/2017/03/04/interpret-confidence-intervals/
 
 #### `broom`
 
-CRAN: [broom: Convert Statistical Analysis Objects into Tidy Tibbles](https://cran.r-project.org/web/packages/broom/index.html)
+CRAN: [broom: Convert Statistical Analysis Objects into Tidy Tibbles](https://cran.r-project.org/package=broom)
 
 [github page](https://github.com/tidymodels/broom)
 
-[Introduction to broom](https://cran.r-project.org/web/packages/broom/vignettes/broom.html)
+[Introduction to broom](https://cran.r-project.org/package=broom/vignettes/broom.html)
 
 David Robinson (2015-03-19) [broom: a package for tidying statistical models into data frames](http://varianceexplained.org/r/broom-intro/)
 
 
 #### `brms`
 
-[brms: Bayesian Regression Models using Stan](https://cran.r-project.org/web/packages/brms/index.html)
+[brms: Bayesian Regression Models using Stan](https://cran.r-project.org/package=brms)
 
 "...an interface to fit Bayesian generalized (non-)linear multivariate multilevel models using Stan"
 
@@ -100,11 +100,11 @@ University of Virginia Library Research Data Services, ["Getting Started with Qu
 
 **package**
 
-CRAN page: [quantreg: Quantile Regression](https://cran.r-project.org/web/packages/quantreg/)
+CRAN page: [quantreg: Quantile Regression](https://cran.r-project.org/package=quantreg/)
 
 **articles**
 
-Koenker, Roger. (?) ["Quantile Regression in R: A Vignette"](https://cran.r-project.org/web/packages/quantreg/vignettes/rq.pdf).
+Koenker, Roger. (?) ["Quantile Regression in R: A Vignette"](https://cran.r-project.org/package=quantreg/vignettes/rq.pdf).
 
 
 

--- a/59_quantitative_methods.Rmd
+++ b/59_quantitative_methods.Rmd
@@ -49,7 +49,7 @@ Arranged by package
 
 **package**
 
-CRAN page: [ei: Ecological Inference](https://cran.r-project.org/web/packages/ei/index.html)
+CRAN page: [ei: Ecological Inference](https://cran.r-project.org/package=ei)
 
 **articles**
 
@@ -88,7 +88,7 @@ documentation: [`fable`](https://fable.tidyverts.org/)
 
 **package**
 
-CRAN page: [prophet: Automatic Forecasting Procedure](https://cran.r-project.org/web/packages/prophet/index.html)
+CRAN page: [prophet: Automatic Forecasting Procedure](https://cran.r-project.org/package=prophet)
 
 documentation: [Prophet: forecasting at scale](https://facebookincubator.github.io/prophet/) 
 
@@ -175,9 +175,9 @@ Thomas Leeper, [Multiple imputation](http://thomasleeper.com/Rcourse/Tutorials/m
 
 **package**
 
-CRAN page: [Amelia: A Program for Missing Data](https://cran.r-project.org/web/packages/Amelia/index.html)
+CRAN page: [Amelia: A Program for Missing Data](https://cran.r-project.org/package=Amelia)
 
-vignette: [Amelia II: A Package for Missing Data](https://cran.r-project.org/web/packages/Amelia/vignettes/amelia.pdf) {PDF version}
+vignette: [Amelia II: A Package for Missing Data](https://cran.r-project.org/package=Amelia/vignettes/amelia.pdf) {PDF version}
 
 description: [Amelia II: A Program for Missing Data](http://gking.harvard.edu/amelia)
 
@@ -186,7 +186,7 @@ github page for [Amelia II](https://github.com/IQSS/Amelia)
 
 #### `BaBooN`
 
-CRAN page: [BaBooN: Bayesian Bootstrap Predictive Mean Matching - Multiple and Single Imputation for Discrete Data](https://cran.r-project.org/web/packages/BaBooN/index.html)
+CRAN page: [BaBooN: Bayesian Bootstrap Predictive Mean Matching - Multiple and Single Imputation for Discrete Data](https://cran.r-project.org/package=BaBooN)
 
 
 
@@ -194,7 +194,7 @@ CRAN page: [BaBooN: Bayesian Bootstrap Predictive Mean Matching - Multiple and S
 
 **package**
 
-CRAN page: [Hmisc: Harrell Miscellaneous](https://cran.r-project.org/web/packages/Hmisc/index.html)
+CRAN page: [Hmisc: Harrell Miscellaneous](https://cran.r-project.org/package=Hmisc)
 
 
 
@@ -202,23 +202,23 @@ CRAN page: [Hmisc: Harrell Miscellaneous](https://cran.r-project.org/web/package
 
 **package**
 
-CRAN page: [mi: Missing Data Imputation and Model Checking](https://cran.r-project.org/web/packages/mi/index.html)
+CRAN page: [mi: Missing Data Imputation and Model Checking](https://cran.r-project.org/package=mi)
 
 **articles**
 
 Su, Gelman, Hill and Yajima (2011) [Multiple Imputation with Diagnostics (mi) in R: Opening Windows into the Black Box](http://www.stat.columbia.edu/~gelman/research/published/mipaper.pdf), _Journal of Statistical Software_, vol. 45.
 
-Ben Goodrich and Jonathan Kropko, 2014-06-16, ["An Example of mi Usage"](https://cran.r-project.org/web/packages/mi/vignettes/mi_vignette.pdf)
+Ben Goodrich and Jonathan Kropko, 2014-06-16, ["An Example of mi Usage"](https://cran.r-project.org/package=mi/vignettes/mi_vignette.pdf)
 
 #### `mice`
 
 **package**
 
-CRAN page: [mice: Multivariate Imputation by Chained Equations](https://cran.r-project.org/web/packages/mice/index.html)
+CRAN page: [mice: Multivariate Imputation by Chained Equations](https://cran.r-project.org/package=mice)
 
 **see also**
 
-package `miceadds` on CRAN: [miceadds: Some Additional Multiple Imputation Functions, Especially for 'mice'](https://cran.r-project.org/web/packages/miceadds/index.html)
+package `miceadds` on CRAN: [miceadds: Some Additional Multiple Imputation Functions, Especially for 'mice'](https://cran.r-project.org/package=miceadds)
 
 
 **articles**
@@ -235,7 +235,7 @@ datascience+, 2015-10-04 and updated 2017-04-28, [Imputing Missing Data with R; 
 
 **package**
 
-CRAN page: [missMDA: Handling Missing Values with Multivariate Data Analysis](https://cran.r-project.org/web/packages/missMDA/index.html)
+CRAN page: [missMDA: Handling Missing Values with Multivariate Data Analysis](https://cran.r-project.org/package=missMDA)
 
 **articles**
 
@@ -247,19 +247,19 @@ francoishusson, 2017-08-15, [Multiple imputation for continuous and categorical 
 
 **package**
 
-CRAN page: [missForest: Nonparametric Missing Value Imputation using Random Forest](https://cran.r-project.org/web/packages/missForest/index.html)
+CRAN page: [missForest: Nonparametric Missing Value Imputation using Random Forest](https://cran.r-project.org/package=missForest)
 
 
 #### `NPBayesImpute`
 
-CRAN page: [NPBayesImpute: Non-Parametric Bayesian Multiple Imputation for Categorical Data](https://cran.r-project.org/web/packages/NPBayesImpute/index.html)
+CRAN page: [NPBayesImpute: Non-Parametric Bayesian Multiple Imputation for Categorical Data](https://cran.r-project.org/package=NPBayesImpute)
 
 
 #### `VIM`
 
 **package**
 
-CRAN page: [VIM: Visualization and Imputation of Missing Values](https://cran.r-project.org/web/packages/VIM/index.html)
+CRAN page: [VIM: Visualization and Imputation of Missing Values](https://cran.r-project.org/package=VIM)
 
 **articles**
 
@@ -371,7 +371,7 @@ DIY Solution
 
 **package**
 
-CRAN page: [anesrake: ANES Raking Implementation](https://cran.r-project.org/web/packages/anesrake/index.html)
+CRAN page: [anesrake: ANES Raking Implementation](https://cran.r-project.org/package=anesrake)
 
 **articles**
 
@@ -385,7 +385,7 @@ Josh Pasek, Matthew DeBell, Jon A. Krosnick (2014-07-26) ["Standardizing!and!Dem
 
 **package**
 
-CRAN page: [ipfp: Fast Implementation of the Iterative Proportional Fitting Procedure in C](https://cran.r-project.org/web/packages/ipfp/)
+CRAN page: [ipfp: Fast Implementation of the Iterative Proportional Fitting Procedure in C](https://cran.r-project.org/package=ipfp/)
 
 github page: [awblocker/ipfp](https://github.com/awblocker/ipfp)
 
@@ -397,7 +397,7 @@ github page: [awblocker/ipfp](https://github.com/awblocker/ipfp)
 
 **package**
 
-CRAN page: [survey: analysis of complex survey samples](https://cran.r-project.org/web/packages/survey/index.html)
+CRAN page: [survey: analysis of complex survey samples](https://cran.r-project.org/package=survey)
 
 homepage: [Survey analysis in R](http://r-survey.r-forge.r-project.org/survey/)
 
@@ -420,7 +420,7 @@ Lumley, Thomas (2010) _Complex Surveys: A Guide to Analysis Using R_, John Wiley
 
 **package**
 
-CRAN page: [weights: Weighting and Weighted Statistics](https://cran.r-project.org/web/packages/weights/index.html)
+CRAN page: [weights: Weighting and Weighted Statistics](https://cran.r-project.org/package=weights)
 
 
 **articles**
@@ -458,18 +458,18 @@ U.S. Census Bureau, [The X-13ARIMA-SEATS Seasonal Adjustment Program](https://ww
 
 **package**
 
-CRAN page: [ggseas: 'stats' for Seasonal Adjustment on the Fly with 'ggplot2'](https://cran.r-project.org/web/packages/ggseas/index.html)
+CRAN page: [ggseas: 'stats' for Seasonal Adjustment on the Fly with 'ggplot2'](https://cran.r-project.org/package=ggseas)
 
-[Vignette](https://cran.r-project.org/web/packages/ggseas/vignettes/ggsdc.html)
+[Vignette](https://cran.r-project.org/package=ggseas/vignettes/ggsdc.html)
 
 
 #### `ggseas`
 
 **package**
 
-CRAN page: [ggseas: 'stats' for Seasonal Adjustment on the Fly with 'ggplot2'](https://cran.r-project.org/web/packages/ggseas/)
+CRAN page: [ggseas: 'stats' for Seasonal Adjustment on the Fly with 'ggplot2'](https://cran.r-project.org/package=ggseas/)
 
-[Vignette](https://cran.r-project.org/web/packages/ggseas/vignettes/ggsdc.html)
+[Vignette](https://cran.r-project.org/package=ggseas/vignettes/ggsdc.html)
 
 **articles**
 
@@ -486,11 +486,11 @@ Ellis, Peter. 2016-02-08. ["ggseas package for seasonal adjustment on the fly wi
 
 Packages the U.S. Census Bureau's gold-standard X13-SEATS-ARIMA for use in R.
 
-"...the best interface on the planet to the X13-SEATS-ARIMA time series analysis application from the US Census Department, which is the industry standard particularly for official statistics agencies doing seasonal adjustment." (Peter Ellis, [vignette for `ggsdc`](https://cran.r-project.org/web/packages/ggseas/vignettes/ggsdc.html.))
+"...the best interface on the planet to the X13-SEATS-ARIMA time series analysis application from the US Census Department, which is the industry standard particularly for official statistics agencies doing seasonal adjustment." (Peter Ellis, [vignette for `ggsdc`](https://cran.r-project.org/package=ggseas/vignettes/ggsdc.html.))
 
 **package**
 
-CRAN page: [seasonal: R Interface to X-13-ARIMA-SEATS'](https://cran.r-project.org/web/packages/seasonal/index.html)
+CRAN page: [seasonal: R Interface to X-13-ARIMA-SEATS'](https://cran.r-project.org/package=seasonal)
 
 github page: [christophsax/seasonal](https://github.com/christophsax/seasonal)
 
@@ -501,7 +501,7 @@ github page: [christophsax/seasonal](https://github.com/christophsax/seasonal)
 
 **package**
 
-CRAN page: [x13binary: Provide the 'x13ashtml' Seasonal Adjustment Binary](https://cran.r-project.org/web/packages/x13binary/index.html)
+CRAN page: [x13binary: Provide the 'x13ashtml' Seasonal Adjustment Binary](https://cran.r-project.org/package=x13binary)
 
 
 
@@ -517,7 +517,7 @@ Arranged by package
 
 **package**
 
-CRAN page: [lavaan: Latent Variable Analysis](https://cran.r-project.org/web/packages/lavaan/index.html)
+CRAN page: [lavaan: Latent Variable Analysis](https://cran.r-project.org/package=lavaan)
 
 **articles**
 
@@ -531,7 +531,7 @@ Grace Charles, 2015-05-20, [First Steps with Structural Equation Modeling](https
 
 **package**
 
-CRAN page: [sem: Structural Equation Models](https://cran.r-project.org/web/packages/sem/)
+CRAN page: [sem: Structural Equation Models](https://cran.r-project.org/package=sem/)
 
 **articles**
 
@@ -575,7 +575,7 @@ Methods for extracting various features from time series data
 
 **package**
 
-CRAN: [tsfeatures: Time Series Feature Extraction](https://cran.r-project.org/web/packages/tsfeatures/index.html)
+CRAN: [tsfeatures: Time Series Feature Extraction](https://cran.r-project.org/package=tsfeatures)
 
 [package webpage](https://pkg.robjhyndman.com/tsfeatures/)
 
@@ -588,7 +588,7 @@ CRAN: [tsfeatures: Time Series Feature Extraction](https://cran.r-project.org/we
 
 **package**
 
-CRAN page: [tsibble: Tidy Temporal Data Frames and Tools](https://cran.r-project.org/web/packages/tsibble/index.html)
+CRAN page: [tsibble: Tidy Temporal Data Frames and Tools](https://cran.r-project.org/package=tsibble)
 
 github page: [tsibble`: Tidy Temporal Data Frames and Tools](https://github.com/tidyverts/tsibble)
 
@@ -603,7 +603,7 @@ Earo Wang and Dianne Cook and Rob J Hyndman, January 2019, "A new tidy data stru
 
 **package**
 
-CRAN page: [padr: Quickly Get Datetime Data Ready for Analysis](https://cran.r-project.org/web/packages/padr/index.html)
+CRAN page: [padr: Quickly Get Datetime Data Ready for Analysis](https://cran.r-project.org/package=padr)
 
 **articles**
 
@@ -614,6 +614,6 @@ Andrew Clark, 2017-07-19, [padr package example](https://www.mytinyshinys.com/20
 
 **package**
 
-CRAN page: [zoo: S3 Infrastructure for Regular and Irregular Time Series (Z's Ordered Observations)](https://cran.r-project.org/web/packages/zoo/index.html)
+CRAN page: [zoo: S3 Infrastructure for Regular and Irregular Time Series (Z's Ordered Observations)](https://cran.r-project.org/package=zoo)
 
 

--- a/60_spatial_data.Rmd
+++ b/60_spatial_data.Rmd
@@ -128,7 +128,7 @@ github page: [cartography](https://github.com/riatelab/cartography)
 
 **package**
 
-CRAN page: [choroplethr: Simplify the Creation of Choropleth Maps in R](https://cran.r-project.org/web/packages/choroplethr/index.html)
+CRAN page: [choroplethr: Simplify the Creation of Choropleth Maps in R](https://cran.r-project.org/package=choroplethr)
 
 **articles**
 
@@ -149,7 +149,7 @@ CRAN page: [choroplethr: Simplify the Creation of Choropleth Maps in R](https://
 **package**
 
 CRAN page: [ggmap: Spatial Visualization with ggplot2]
-(https://cran.r-project.org/web/packages/ggmap/index.html)
+(https://cran.r-project.org/package=ggmap)
 
 **articles**
 
@@ -170,7 +170,7 @@ CRAN page: [ggmap: Spatial Visualization with ggplot2]
 **package**
 
 CRAN page: [ggspatial: Spatial Data Framework for ggplot2]
-(https://cran.r-project.org/web/packages/ggspatial/index.html)
+(https://cran.r-project.org/package=ggspatial)
 
 gihub page: [A ggplot2 R extension for plotting Spatial objects](https://github.com/paleolimbot/ggspatial)
 
@@ -180,7 +180,7 @@ gihub page: [A ggplot2 R extension for plotting Spatial objects](https://github.
 **package**
 
 CRAN page: [GISTools: Some further GIS capabilities for R]
-(https://cran.r-project.org/web/packages/GISTools/index.html)
+(https://cran.r-project.org/package=GISTools)
 
 **articles**
 
@@ -188,7 +188,7 @@ CRAN page: [GISTools: Some further GIS capabilities for R]
 
 **package**
 
-CRAN page: [idbr: R Interface to the US Census Bureau International Data Base API](https://cran.r-project.org/web/packages/idbr/)
+CRAN page: [idbr: R Interface to the US Census Bureau International Data Base API](https://cran.r-project.org/package=idbr/)
 
 github page: [idbr](https://github.com/walkerke/idbr)
 
@@ -201,7 +201,7 @@ Kyle Walker, [Visualizing international demographic indicators with idbr and Plo
 
 **package**
 
-CRAN: [leaflet: Create Interactive Web Maps with the JavaScript 'Leaflet' Library](https://cran.r-project.org/web/packages/leaflet/index.html)
+CRAN: [leaflet: Create Interactive Web Maps with the JavaScript 'Leaflet' Library](https://cran.r-project.org/package=leaflet)
 
 RStudio on github: [rstudio/leaflet](https://github.com/rstudio/leaflet)
 
@@ -222,7 +222,7 @@ Kyle Walker (2016) ["Using a new Mapbox Studio map in an R Leaflet project"](htt
 
 **package**
 
-CRAN: [sf: Simple Features for R](https://cran.r-project.org/web/packages/sf/index.html)
+CRAN: [sf: Simple Features for R](https://cran.r-project.org/package=sf)
 
 
 
@@ -231,9 +231,9 @@ CRAN: [sf: Simple Features for R](https://cran.r-project.org/web/packages/sf/ind
 
 **package**
 
-CRAN: [sp: Classes and Methods for Spatial Data](https://cran.r-project.org/web/packages/sp/index.html)
+CRAN: [sp: Classes and Methods for Spatial Data](https://cran.r-project.org/package=sp)
 
-vignettes: Edzer Pebesma and Roger S. Bivand (2005): [Classes and Methods for Spatial Data: the sp Package](https://cran.r-project.org/web/packages/sp/vignettes/intro_sp.pdf)
+vignettes: Edzer Pebesma and Roger S. Bivand (2005): [Classes and Methods for Spatial Data: the sp Package](https://cran.r-project.org/package=sp/vignettes/intro_sp.pdf)
 
 
 **articles**
@@ -245,9 +245,9 @@ Edzer Pebesma (2008) [Introduction to R and package sp](http://pebesma.staff.ifg
 
 **package**
 
-CRAN: [tmap: Thematic Maps](https://cran.r-project.org/web/packages/tmap/index.html)
+CRAN: [tmap: Thematic Maps](https://cran.r-project.org/package=tmap)
 
-vignettes: [tmap in a nutshell](https://cran.r-project.org/web/packages/tmap/vignettes/tmap-nutshell.html)
+vignettes: [tmap in a nutshell](https://cran.r-project.org/package=tmap/vignettes/tmap-nutshell.html)
 
 GitHub: [`tmap`](https://github.com/mtennekes/tmap)
 

--- a/61_small_area_estimation.Rmd
+++ b/61_small_area_estimation.Rmd
@@ -114,7 +114,7 @@ Andrés Gutiérrez, 2017-04-16, _Small Area Estimation 101_(https://hagutierrezr
 
 **package**
 
-CRAN page: [sae: Small Area Estimation](https://cran.r-project.org/web/packages/sae/index.html)
+CRAN page: [sae: Small Area Estimation](https://cran.r-project.org/package=sae)
 
 **articles**
 
@@ -124,7 +124,7 @@ Molina, Isabel and Yolanda Marhuenda (2015) ["sae: An R Package for Small Area E
 
 **package**
 
-CRAN page: [sae2: Small Area Estimation: Time-series Models](https://cran.r-project.org/web/packages/sae2/index.html)
+CRAN page: [sae2: Small Area Estimation: Time-series Models](https://cran.r-project.org/package=sae2)
 
 **articles**
 

--- a/70_text_analysis.rmd
+++ b/70_text_analysis.rmd
@@ -52,7 +52,7 @@ Julia Silge (2016) ["You Must Allow Me To Tell You How Ardently I Admire and Lov
 
 **package**
 
-CRAN page: [monkeylearn: Accesses the Monkeylearn API for Text Classifiers and Extractors](https://cran.r-project.org/web/packages/monkeylearn/index.html)
+CRAN page: [monkeylearn: Accesses the Monkeylearn API for Text Classifiers and Extractors](https://cran.r-project.org/package=monkeylearn)
 
 github page: [monkeylearn: R package for text analysis with Monkeylearn](https://github.com/ropensci/monkeylearn)
 
@@ -67,19 +67,19 @@ github page: [monkeylearn: R package for text analysis with Monkeylearn](https:/
 
 **package**
 
-CRAN page: [quanteda: Quantitative Analysis of Textual Data](https://cran.r-project.org/web/packages/quanteda/index.html)
+CRAN page: [quanteda: Quantitative Analysis of Textual Data](https://cran.r-project.org/package=quanteda)
 
 
 **articles**
 
-["Getting Started with `quanteda`"](https://cran.r-project.org/web/packages/quanteda/vignettes/quickstart.html) (package vignette)
+["Getting Started with `quanteda`"](https://cran.r-project.org/package=quanteda/vignettes/quickstart.html) (package vignette)
 
 
 #### `tidytext`
 
 **package**
 
-CRAN page: [tidytext: Text Mining using 'dplyr', 'ggplot2', and Other Tidy Tools](https://cran.r-project.org/web/packages/tidytext/)
+CRAN page: [tidytext: Text Mining using 'dplyr', 'ggplot2', and Other Tidy Tools](https://cran.r-project.org/package=tidytext/)
 
 github repo: [tidytext on github](https://github.com/juliasilge/tidytext)
 
@@ -89,19 +89,19 @@ Julia Silge, ["Term Frequency and tf-idf Using Tidy Data Principles"](http://jul
 
 []()
 
-Julia Silge and David Robinson (2016-10-27) ["Introduction to `tidytext`"](https://cran.r-project.org/web/packages/tidytext/vignettes/tidytext.html) (package vignette)
+Julia Silge and David Robinson (2016-10-27) ["Introduction to `tidytext`"](https://cran.r-project.org/package=tidytext/vignettes/tidytext.html) (package vignette)
 
 
 #### `tm`
 
 **package**
 
-CRAN page: [tm: Text Mining Package](https://cran.r-project.org/web/packages/tm/index.html)
+CRAN page: [tm: Text Mining Package](https://cran.r-project.org/package=tm)
 
 
 **articles**
 
-Inigo Feinerer (2015) ["Introduction to the `tm` Package: Text Mining in R"](https://cran.r-project.org/web/packages/tm/vignettes/tm.pdf) (package vignette)
+Inigo Feinerer (2015) ["Introduction to the `tm` Package: Text Mining in R"](https://cran.r-project.org/package=tm/vignettes/tm.pdf) (package vignette)
 
 Ingo Feinerer, Kurt Hornik, David Meyer (2007) ["Text Mining Infrastructure in R"](https://www.jstatsoft.org/article/view/v025i05), _Journal of Statistical Software_, 25 (5).
 

--- a/80_communicating.rmd
+++ b/80_communicating.rmd
@@ -32,7 +32,7 @@ https://twitter.com/AllieSherier/status/1098988779833040903
 
 **package**
 
-CRAN page: [kableExtra: Construct Complex Table with 'kable' and Pipe Syntax](https://cran.r-project.org/web/packages/kableExtra/index.html)
+CRAN page: [kableExtra: Construct Complex Table with 'kable' and Pipe Syntax](https://cran.r-project.org/package=kableExtra)
 
 github page: [Construct Complex Table with knitr::kable() + pipe](https://github.com/haozhu233/kableExtra)
 

--- a/86_presentations.Rmd
+++ b/86_presentations.Rmd
@@ -64,7 +64,7 @@ Jessica Calarco, July 31, 2018-07-31, [Conference Talks](http://www.jessicacalar
 
 **package**
 
-CRAN: [xaringan: Presentation Ninja](https://cran.r-project.org/web/packages/xaringan/index.html)
+CRAN: [xaringan: Presentation Ninja](https://cran.r-project.org/package=xaringan)
 
 github: [`xaringan`](https://github.com/yihui/xaringan)
 


### PR DESCRIPTION
CRAN [asks people](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) to use this URL variant when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.